### PR TITLE
FIX: test_errors 3018 !== 1015

### DIFF
--- a/src/tests/test_errors.rs
+++ b/src/tests/test_errors.rs
@@ -118,7 +118,7 @@ fn test_errors() {
     if *NODE_SE {
         check_error(&result, 1015, None) // 1015 - code missing              
     } else {
-        check_error(&result, 1015, Some(real_original_code)) // 1015 - code missing
+        check_error(&result, 3018, Some(real_original_code)) // old:1015 - AccountCodeMissing, new:3018 - ContractsLocalRunFailed 
     };
 
     // normal deploy


### PR DESCRIPTION
runLocal test fails with ContractsLocalRunFailed = 3018
instead of AccountCodeMissing = 1015
https://github.com/tonlabs/ton-labs-executor/commit/dd6db9023e69cf77fe500fa9cdd10eabdcaed23b